### PR TITLE
Fix Hex bytes concat padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.0.1] - 2025-09-23
+### Changed
+- Prevented padding zero bytes when promoting short `Hex::Bytes` concatenations to `Vec` storage so that previously stored payload is preserved during overflow handling.
+
+### Added
+- Added a regression test covering concatenation of `Hex::Bytes` with a long `Hex::Vector` to ensure no spurious zeros appear between operands.
+
+### Maintenance
+- Bumped the crate version to `0.0.1` to publish the concatenation fix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "sodg"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "sodg"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2024"
 repository = "https://github.com/objectionary/sodg"
 description = "Surging Object DiGraph (SODG)"

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -476,7 +476,7 @@ impl Hex {
                     Self::Bytes(bytes, l + h.len())
                 } else {
                     let mut v = Vec::new();
-                    v.extend_from_slice(b);
+                    v.extend_from_slice(&b[..*l]);
                     v.extend_from_slice(h.bytes());
                     Self::Vector(v)
                 }
@@ -804,6 +804,19 @@ mod tests {
     }
 
     #[test]
+    fn concatenates_bytes_with_long_vector_without_padding() {
+        let bytes = Hex::from_slice(&[0xAB, 0xCD]);
+        let vector = Hex::from_vec((1..=16).map(|value| value as u8).collect());
+        let result = bytes.concat(&vector);
+        let mut expected = Vec::with_capacity(bytes.len() + vector.len());
+        expected.extend_from_slice(bytes.bytes());
+        expected.extend_from_slice(vector.bytes());
+        assert_eq!(result.len(), expected.len());
+        assert_eq!(result.bytes()[2], 0x01);
+        assert_eq!(result.bytes(), expected.as_slice());
+    }
+
+    #[test]
     fn creates_from_big_slice() {
         let s: [u8; 9] = [0xAB, 0xD8, 0xAB, 0xD8, 0xAB, 0xD8, 0xAB, 0xD8, 0xAB];
         let mut accum = vec![];
@@ -823,7 +836,7 @@ mod tests {
         let b = Hex::from_slice(b"as_bytesss");
         let c = Hex::from_vec(vec![0x12, 0xAD]);
         let res = a.concat(&b).concat(&c);
-        assert_eq!(20, res.len());
+        assert_eq!(a.len() + b.len() + c.len(), res.len());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! sodg.bind(0, 1, Label::from_str("foo").unwrap());
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/sodg/0.0.0")]
+#![doc(html_root_url = "https://docs.rs/sodg/0.0.1")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![allow(clippy::multiple_inherent_impl)]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -97,12 +97,11 @@ impl<const N: usize> Sodg<N> {
             self.merge_rec(g, matched, *to, mapped)?;
         }
         for (a, to) in g.kids(right) {
-            if let Some(first) = self.kid(left, *a) {
-                if let Some(second) = mapped.get(to) {
-                    if first != *second {
-                        self.join(first, *second);
-                    }
-                }
+            if let Some(first) = self.kid(left, *a)
+                && let Some(second) = mapped.get(to)
+                && first != *second
+            {
+                self.join(first, *second);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- avoid copying unused capacity when `Hex::Bytes` concatenations overflow the inline buffer
- add a regression test covering byte/vector concatenation without padding
- bump the crate version to 0.0.1 and record the fix in the changelog

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: unable to fetch advisory database in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2731b72f0832bb6cc7d95f9cfd207