### PR TITLE
Fix changelog markdownlint issues and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
 # Changelog
 
-## [0.0.1] - 2025-09-23
+## [0.0.2] - 2025-09-23
+
 ### Changed
-- Prevented padding zero bytes when promoting short `Hex::Bytes` concatenations to `Vec` storage so that previously stored payload is preserved during overflow handling.
+
+- Formatted the changelog to comply with markdownlint requirements.
+
+## [0.0.1] - 2025-09-23
+
+### Changed
+
+- Prevented padding zero bytes when promoting short `Hex::Bytes`
+  concatenations to `Vec` storage so that previously stored payload is
+  preserved during overflow handling.
 
 ### Added
-- Added a regression test covering concatenation of `Hex::Bytes` with a long `Hex::Vector` to ensure no spurious zeros appear between operands.
+
+- Added a regression test covering concatenation of `Hex::Bytes` with a
+  long `Hex::Vector` to ensure no spurious zeros appear between operands.
 
 ### Maintenance
+
 - Bumped the crate version to `0.0.1` to publish the concatenation fix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "sodg"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "sodg"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 repository = "https://github.com/objectionary/sodg"
 description = "Surging Object DiGraph (SODG)"


### PR DESCRIPTION
## Summary
- add a 0.0.2 release entry and reformat the changelog so it satisfies markdownlint spacing and wrapping rules
- bump the crate version metadata to 0.0.2 to align with the new changelog entry

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo deny check` *(fails: unable to fetch advisory database due to network error)*
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68d27a2ae8b8832b95420008cddbfd1b