### PR TITLE
Fix Label alpha parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.0.3] - 2025-09-23
+
+### Fixed (0.0.3)
+
+- Treated `Label::from_str("α")` as `Label::Greek('α')` to avoid parsing an empty
+  suffix while preserving existing `αN` parsing.
+
+### Added (0.0.3)
+
+- Introduced a regression test ensuring the bare alpha label maps to the Greek
+  variant.
+
 ## [0.0.2] - 2025-09-23
 
 ### Changed (0.0.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "sodg"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "sodg"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 repository = "https://github.com/objectionary/sodg"
 description = "Surging Object DiGraph (SODG)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! sodg.bind(0, 1, Label::from_str("foo").unwrap());
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/sodg/0.0.1")]
+#![doc(html_root_url = "https://docs.rs/sodg/0.0.3")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![allow(clippy::multiple_inherent_impl)]


### PR DESCRIPTION
## Summary
- only treat labels starting with `α` as numeric when a suffix is present and add a regression test for bare alpha labels
- bump the crate metadata to version 0.0.3 and refresh the changelog and documentation root URL

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo clippy -- -D warnings
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: unable to fetch advisory database due to network error)*

------
https://chatgpt.com/codex/tasks/task_e_68d283ebeb84832bbba4ab55d26631b9