### PR TITLE
Add context for missing vertices during merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.0.4] - 2025-09-23
+
+### Fixed (0.0.4)
+
+- Added contextual information to missing-vertex merge failures so callers
+  receive actionable diagnostics instead of opaque errors.
+
+### Added (0.0.4)
+
+- Introduced a regression test to cover the missing-vertex branch of the merge
+  logic and guarantee the contextual error remains wired.
+
 ## [0.0.3] - 2025-09-23
 
 ### Fixed (0.0.3)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "sodg"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "sodg"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 repository = "https://github.com/objectionary/sodg"
 description = "Surging Object DiGraph (SODG)"


### PR DESCRIPTION
## Summary
- add contextual error reporting in the merge recursion when a vertex cannot be retrieved
- add a regression test covering the missing-vertex path to ensure the new error wiring stays intact
- bump the crate version to 0.0.4 and document the change in the changelog

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: unable to reach https://github.com/RustSec/advisory-db)*

------
https://chatgpt.com/codex/tasks/task_e_68d33a253c64832b95a3c6f9046ef9b5