### PR TITLE
Optimize script parsing and hex handling

### DIFF
--- a/src/label.rs
+++ b/src/label.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use std::fmt::{self, Debug, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter, Write as _};
 use std::str::FromStr;
 
 use anyhow::bail;
@@ -46,10 +46,16 @@ impl Display for Label {
 impl Debug for Label {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            Self::Greek(c) => f.write_str(c.to_string().as_str()),
-            Self::Alpha(i) => f.write_str(format!("α{i}").as_str()),
+            Self::Greek(c) => f.write_char(c),
+            Self::Alpha(i) => {
+                f.write_char('α')?;
+                Display::fmt(&i, f)
+            }
             Self::Str(a) => {
-                f.write_str(a.iter().filter(|c| **c != ' ').collect::<String>().as_str())
+                for c in a.iter().copied().filter(|c| *c != ' ') {
+                    f.write_char(c)?;
+                }
+                Ok(())
             }
         }
     }

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str::FromStr as _;
-use std::sync::LazyLock as Lazy;
 
 use anyhow::{Context as _, Result, bail};
 use log::trace;
-use regex::Regex;
 
 use crate::{Hex, Script};
 use crate::{Label, Sodg};
@@ -52,8 +51,9 @@ impl Script {
     ///
     /// If impossible to deploy, an error will be returned.
     pub fn deploy_to<const N: usize>(&mut self, g: &mut Sodg<N>) -> Result<usize> {
+        let commands = Self::strip_comments(self.txt.as_str());
         let mut pos = 0;
-        for cmd in &self.commands() {
+        for cmd in commands.split(';').map(str::trim).filter(|t| !t.is_empty()) {
             trace!("#deploy_to: deploying command no.{} '{}'...", pos + 1, cmd);
             self.deploy_one(cmd, g)
                 .with_context(|| format!("Failure at the command no.{pos}: '{cmd}'"))?;
@@ -62,17 +62,26 @@ impl Script {
         Ok(pos)
     }
 
-    /// Get all commands.
-    fn commands(&self) -> Vec<String> {
-        static STRIP_COMMENTS: Lazy<Regex> = Lazy::new(|| Regex::new("#.*(?:\n|$)").unwrap());
-        let text = self.txt.as_str();
-        let clean: &str = &STRIP_COMMENTS.replace_all(text, "");
-        clean
-            .split(';')
-            .map(str::trim)
-            .filter(|t| !t.is_empty())
-            .map(ToString::to_string)
-            .collect()
+    fn strip_comments(text: &str) -> String {
+        if !text.contains('#') {
+            return text.to_string();
+        }
+        let mut result = String::with_capacity(text.len());
+        let mut in_comment = false;
+        for ch in text.chars() {
+            if in_comment {
+                if ch == '\n' {
+                    in_comment = false;
+                }
+                continue;
+            }
+            if ch == '#' {
+                in_comment = true;
+                continue;
+            }
+            result.push(ch);
+        }
+        result
     }
 
     /// Deploy a single command to the [`Sodg`].
@@ -81,17 +90,21 @@ impl Script {
     ///
     /// If impossible to deploy, an error will be returned.
     fn deploy_one<const N: usize>(&mut self, cmd: &str, g: &mut Sodg<N>) -> Result<()> {
-        static LINE: Lazy<Regex> = Lazy::new(|| Regex::new("^([A-Z]+) *\\(([^)]*)\\)$").unwrap());
-        let cap = LINE
-            .captures(cmd)
+        let (name, rest) = cmd
+            .split_once('(')
             .with_context(|| format!("Can't parse '{cmd}'"))?;
-        let args: Vec<String> = cap[2]
+        let trimmed_name = name.trim();
+        let arguments = rest
+            .rfind(')')
+            .map(|idx| &rest[..idx])
+            .context("Missing closing parenthesis")?;
+        let args: Vec<String> = arguments
             .split(',')
             .map(str::trim)
             .filter(|t| !t.is_empty())
             .map(ToString::to_string)
             .collect();
-        match &cap[1] {
+        match trimmed_name {
             "ADD" => {
                 let v = self.parse(args.first().context("V is expected")?, g)?;
                 g.add(v);
@@ -120,17 +133,29 @@ impl Script {
     ///
     /// If impossible to parse, an error will be returned.
     fn parse_data(s: &str) -> Result<Hex> {
-        static DATA_STRIP: Lazy<Regex> = Lazy::new(|| Regex::new("[ \t\n\r\\-]").unwrap());
-        static DATA: Lazy<Regex> =
-            Lazy::new(|| Regex::new("^[0-9A-Fa-f]{2}([0-9A-Fa-f]{2})*$").unwrap());
-        let d: &str = &DATA_STRIP.replace_all(s, "");
-        if !DATA.is_match(d) {
-            bail!("Can't parse data '{s}'");
+        let cleaned: Cow<'_, str> = if s
+            .chars()
+            .any(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | '-'))
+        {
+            Cow::Owned(
+                s.chars()
+                    .filter(|c| !matches!(c, ' ' | '\t' | '\n' | '\r' | '-'))
+                    .collect(),
+            )
+        } else {
+            Cow::Borrowed(s)
+        };
+        if cleaned.len() % 2 != 0 {
+            bail!("Can't parse data '{s}': odd number of hexadecimal digits");
         }
-        let bytes: Vec<u8> = (0..d.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&d[i..i + 2], 16).unwrap())
-            .collect();
+        let mut bytes = Vec::with_capacity(cleaned.len() / 2);
+        for (chunk_index, chunk) in cleaned.as_bytes().chunks_exact(2).enumerate() {
+            let byte = Self::parse_hex_pair(chunk).with_context(|| {
+                let pos = chunk_index * 2;
+                format!("Can't parse data '{s}' at position {pos}")
+            })?;
+            bytes.push(byte);
+        }
         Ok(Hex::from_vec(bytes))
     }
 
@@ -142,7 +167,7 @@ impl Script {
     fn parse<const N: usize>(&mut self, s: &str, g: &mut Sodg<N>) -> Result<usize> {
         let head = s.chars().next().context("Empty identifier")?;
         if head == '$' || head == 'ν' {
-            let tail: String = s.chars().skip(1).collect::<Vec<_>>().into_iter().collect();
+            let tail: String = s.chars().skip(1).collect();
             if head == '$' {
                 Ok(*self.vars.entry(tail).or_insert_with(|| g.next_id()))
             } else {
@@ -152,6 +177,23 @@ impl Script {
         } else {
             let v = usize::from_str(s).with_context(|| format!("Parsing of '{s}' failed"))?;
             Ok(v)
+        }
+    }
+
+    fn parse_hex_pair(pair: &[u8]) -> Result<u8> {
+        let high = Self::parse_hex_digit(pair[0])
+            .with_context(|| format!("Invalid hexadecimal digit '{}'", char::from(pair[0])))?;
+        let low = Self::parse_hex_digit(pair[1])
+            .with_context(|| format!("Invalid hexadecimal digit '{}'", char::from(pair[1])))?;
+        Ok((high << 4) | low)
+    }
+
+    const fn parse_hex_digit(digit: u8) -> Option<u8> {
+        match digit {
+            b'0'..=b'9' => Some(digit - b'0'),
+            b'a'..=b'f' => Some(digit - b'a' + 10),
+            b'A'..=b'F' => Some(digit - b'A' + 10),
+            _ => None,
         }
     }
 }
@@ -182,5 +224,22 @@ mod tests {
         let mut s = Script::from_str("ADD(0);\n# trailing comment");
         let total = s.deploy_to(&mut g).unwrap();
         assert_eq!(1, total);
+    }
+
+    #[test]
+    fn parse_data_supports_mixed_formatting() {
+        let hex = Script::parse_data("FF-00 0A\n0B").unwrap();
+        assert_eq!(hex.bytes(), &[0xFF, 0x00, 0x0A, 0x0B]);
+    }
+
+    #[test]
+    fn parse_data_rejects_invalid_digit() {
+        assert!(Script::parse_data("ZZ").is_err());
+    }
+
+    #[test]
+    fn strip_comments_removes_entire_comment_line() {
+        let cleaned = Script::strip_comments("ADD(0);\n# comment\nADD(1);");
+        assert_eq!(cleaned, "ADD(0);\nADD(1);");
     }
 }


### PR DESCRIPTION
## Summary
- replace regex-based script parsing with manual parsing to reduce allocations and improve error handling
- implement allocation-aware hexadecimal parsing for scripts together with unit coverage for edge cases
- streamline `Label` debug formatting to avoid intermediate `String` allocations

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo test --all
- cargo clippy -- -D warnings
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: network error fetching advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d351051af0832bb9d165e51b7c1bcf