### PR TITLE
Add tests for branch transitions in bind

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -340,6 +340,67 @@ mod tests {
     }
 
     #[test]
+    fn moves_static_vertices_into_dynamic_branch() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::Alpha(0));
+        let branch = g.vertices.get(1).unwrap().branch;
+        assert_ne!(BRANCH_STATIC, branch);
+        assert_eq!(branch, g.vertices.get(2).unwrap().branch);
+        let members: Vec<usize> = g.branches.get(branch).unwrap().iter().copied().collect();
+        assert!(members.contains(&1));
+        assert!(members.contains(&2));
+    }
+
+    #[test]
+    fn joins_static_vertex_to_existing_branch() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::Alpha(0));
+        let dynamic_branch = g.vertices.get(1).unwrap().branch;
+        g.add(3);
+        assert_eq!(BRANCH_STATIC, g.vertices.get(3).unwrap().branch);
+        g.bind(3, 1, Label::Alpha(1));
+        assert_eq!(dynamic_branch, g.vertices.get(3).unwrap().branch);
+        let members: Vec<usize> = g
+            .branches
+            .get(dynamic_branch)
+            .unwrap()
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(3, members.len());
+        assert!(members.contains(&1));
+        assert!(members.contains(&2));
+        assert!(members.contains(&3));
+    }
+
+    #[test]
+    fn promotes_target_from_static_branch() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::Alpha(0));
+        let dynamic_branch = g.vertices.get(1).unwrap().branch;
+        g.add(3);
+        assert_eq!(BRANCH_STATIC, g.vertices.get(3).unwrap().branch);
+        g.bind(1, 3, Label::Alpha(1));
+        assert_eq!(dynamic_branch, g.vertices.get(3).unwrap().branch);
+        let members: Vec<usize> = g
+            .branches
+            .get(dynamic_branch)
+            .unwrap()
+            .iter()
+            .copied()
+            .collect();
+        assert!(members.contains(&1));
+        assert!(members.contains(&2));
+        assert!(members.contains(&3));
+    }
+
+    #[test]
     fn binds_to_root() {
         let mut g: Sodg<16> = Sodg::empty(256);
         g.add(0);


### PR DESCRIPTION
## Summary
- add focused tests exercising `Sodg::bind` branch management paths when both vertices are static, only the source vertex is static, and only the target vertex is static

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: unable to fetch advisory database from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68d374860b30832bba16adac864a80dd