### PR TITLE
Optimize graph size helpers

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,19 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::Sodg;
+use crate::{BRANCH_NONE, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Get total number of vertices in the graph.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.keys().len()
+        self.vertices
+            .iter()
+            .filter(|(_, vertex)| vertex.branch != BRANCH_NONE)
+            .count()
     }
 
     /// Is it empty?
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        !self
+            .vertices
+            .iter()
+            .any(|(_, vertex)| vertex.branch != BRANCH_NONE)
     }
 
     /// Get keys of all vertices alive?
@@ -21,9 +27,8 @@ impl<const N: usize> Sodg<N> {
     pub fn keys(&self) -> Vec<usize> {
         self.vertices
             .iter()
-            .filter(|(_, vtx)| vtx.branch != 0)
-            .map(|(v, _)| v)
-            .collect::<Vec<usize>>()
+            .filter_map(|(vertex_id, vertex)| (vertex.branch != BRANCH_NONE).then_some(vertex_id))
+            .collect()
     }
 }
 
@@ -35,5 +40,23 @@ mod tests {
     fn counts_vertices() {
         let g: Sodg<16> = Sodg::empty(256);
         assert_eq!(0, g.len());
+    }
+
+    #[test]
+    fn reports_emptiness() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        assert!(g.is_empty());
+        g.add(0);
+        assert!(!g.is_empty());
+    }
+
+    #[test]
+    fn collects_alive_keys() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(2);
+        let mut keys = g.keys();
+        keys.sort_unstable();
+        assert_eq!(vec![0, 2], keys);
     }
 }


### PR DESCRIPTION
## Summary
- compute `Sodg::len` and `Sodg::is_empty` without allocating intermediate vectors
- tighten `Sodg::keys` filtering and extend the unit test coverage of the size helpers

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo deny check *(fails: unable to fetch advisory database)*
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68d37ee4ec70832bab657468b20cb707