### PR TITLE
Add label interner infrastructure

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -10,6 +10,7 @@ impl<const N: usize> Clone for Sodg<N> {
             vertices: self.vertices.clone(),
             branches: self.branches.clone(),
             stores: self.stores.clone(),
+            labels: self.labels.clone(),
             next_v: self.next_v,
         }
     }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -3,7 +3,7 @@
 
 use emap::Map;
 
-use crate::{Hex, MAX_BRANCHES, Persistence, Sodg, Vertex};
+use crate::{Hex, LabelInterner, MAX_BRANCHES, Persistence, Sodg, Vertex};
 
 impl<const N: usize> Sodg<N> {
     /// Make an empty [`Sodg`], with no vertices and no edges.
@@ -25,6 +25,7 @@ impl<const N: usize> Sodg<N> {
             ),
             stores: Map::with_capacity_some(MAX_BRANCHES, 0),
             branches: Map::with_capacity_some(MAX_BRANCHES, microstack::Stack::new()),
+            labels: LabelInterner::default(),
             next_v: 0,
         };
         g.branches.insert(0, microstack::Stack::from_vec(vec![0]));

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+//! Label interning utilities.
+//!
+//! The historic [`Label`] enum models structured edge labels, while the
+//! related issue expects labels to behave like `&str`. Instead of replacing the
+//! enum with a string-based representation, we canonicalize every [`Label`]
+//! into its string form at the interning boundary. This keeps the enum-based
+//! API intact while ensuring that external integrations relying on `&str`
+//! semantics continue to operate on stable UTF-8 text identifiers.
+
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Label;
+
+/// Identifier of an interned label.
+pub type LabelId = u32;
+
+/// Errors that may occur while working with a [`LabelInterner`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabelInternerError {
+    /// The number of unique labels exceeded the representable [`LabelId`] range.
+    CapacityExceeded,
+}
+
+impl Display for LabelInternerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::CapacityExceeded => f.write_str("label pool exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for LabelInternerError {}
+
+/// Maintains a bijection between labels and compact identifiers.
+///
+/// The interner stores labels by their canonical UTF-8 representation while
+/// preserving stable numeric identifiers. `0` is reserved to denote a missing
+/// label.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LabelInterner {
+    forward: HashMap<String, LabelId>,
+    reverse: HashMap<LabelId, String>,
+    #[serde(default)]
+    next: NextLabelId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+struct NextLabelId(LabelId);
+
+impl Default for NextLabelId {
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+impl NextLabelId {
+    const fn allocate(&mut self) -> Result<LabelId, LabelInternerError> {
+        let current = self.0;
+        if current == LabelId::MAX {
+            return Err(LabelInternerError::CapacityExceeded);
+        }
+        self.0 = current + 1;
+        Ok(current)
+    }
+}
+
+impl LabelInterner {
+    /// Ensure the provided [`Label`] has a stable identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LabelInternerError::CapacityExceeded`] if there is no free
+    /// identifier left.
+    pub fn get_or_intern(&mut self, label: &Label) -> Result<LabelId, LabelInternerError> {
+        let key = canonical_form(label);
+        if let Some(id) = self.forward.get(&key) {
+            return Ok(*id);
+        }
+        let id = self.next.allocate()?;
+        self.forward.insert(key.clone(), id);
+        self.reverse.insert(id, key);
+        Ok(id)
+    }
+
+    /// Retrieve the identifier previously assigned to [`label`](Label).
+    #[must_use]
+    pub fn get(&self, label: &Label) -> Option<LabelId> {
+        let key = canonical_form(label);
+        self.forward.get(&key).copied()
+    }
+
+    /// Resolve an identifier into its canonical UTF-8 label.
+    pub fn resolve(&self, id: LabelId) -> Option<&str> {
+        if id == 0 {
+            return None;
+        }
+        self.reverse.get(&id).map(String::as_str)
+    }
+}
+
+fn canonical_form(label: &Label) -> String {
+    match label {
+        Label::Greek(ch) => ch.to_string(),
+        Label::Alpha(idx) => format!("α{idx}"),
+        Label::Str(chars) => chars.iter().filter(|ch| **ch != ' ').collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use super::*;
+
+    #[test]
+    fn interns_labels_once() {
+        let mut interner = LabelInterner::default();
+        let label = Label::Alpha(0);
+        let first = interner.get_or_intern(&label).unwrap();
+        let second = interner.get_or_intern(&label).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn get_returns_existing_identifier() {
+        let mut interner = LabelInterner::default();
+        let label = Label::Greek('λ');
+        let id = interner.get_or_intern(&label).unwrap();
+        assert_eq!(Some(id), interner.get(&label));
+    }
+
+    #[test]
+    fn resolve_returns_none_for_missing() {
+        let interner = LabelInterner::default();
+        assert_eq!(None, interner.resolve(0));
+        assert_eq!(None, interner.resolve(42));
+    }
+
+    #[test]
+    fn round_trip_with_strings() {
+        let mut interner = LabelInterner::default();
+        let label = Label::from_str("hello").unwrap();
+        let id = interner.get_or_intern(&label).unwrap();
+        assert_eq!(Some("hello"), interner.resolve(id));
+    }
+
+    #[test]
+    fn respects_capacity_limit() {
+        let mut interner = LabelInterner::default();
+        interner.next = NextLabelId(LabelId::MAX);
+        let label = Label::Alpha(123);
+        assert!(matches!(
+            interner.get_or_intern(&label),
+            Err(LabelInternerError::CapacityExceeded)
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod dot;
 mod hex;
 mod inspect;
 mod label;
+mod labels;
 mod merge;
 mod misc;
 mod next;
@@ -45,6 +46,8 @@ mod script;
 mod serialization;
 mod slice;
 mod xml;
+
+pub use crate::labels::{LabelId, LabelInterner, LabelInternerError};
 
 const HEX_SIZE: usize = 8;
 const MAX_BRANCHES: usize = 16;
@@ -75,6 +78,10 @@ pub enum Hex {
 }
 
 /// A label on an edge.
+///
+/// Labels remain strongly typed through this enum, while the
+/// [`LabelInterner`] stores their canonical UTF-8 representation to match the
+/// `&str`-based expectations of external integrations.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]
 pub enum Label {
     Greek(char),
@@ -127,6 +134,8 @@ pub struct Sodg<const N: usize> {
     stores: emap::Map<usize>,
     branches: emap::Map<microstack::Stack<usize, MAX_BRANCH_SIZE>>,
     vertices: emap::Map<Vertex<N>>,
+    /// Interned labels that back the graph's edge metadata.
+    labels: LabelInterner,
     /// This is the next ID of a vertex to be returned by the [`Sodg::next_v`] function.
     #[serde(skip_serializing, skip_deserializing)]
     next_v: usize,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -97,12 +97,11 @@ impl<const N: usize> Sodg<N> {
             self.merge_rec(g, matched, *to, mapped)?;
         }
         for (a, to) in g.kids(right) {
-            if let Some(first) = self.kid(left, *a) {
-                if let Some(second) = mapped.get(to) {
-                    if first != *second {
-                        self.join(first, *second);
-                    }
-                }
+            if let Some(first) = self.kid(left, *a)
+                && let Some(second) = mapped.get(to)
+                && first != *second
+            {
+                self.join(first, *second);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- add a label interner that canonicalizes enum labels to strings and exposes typed identifiers
- embed the label interner in `Sodg` and update constructors, cloning, and serialization accordingly
- document the canonicalization decision and tidy merge logic to satisfy new linting requirements

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: unable to reach advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e9b8b2b0832b8352e367d5ca6480