### PR TITLE
Refine label formatting and merge helpers

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -23,7 +23,10 @@ impl<const N: usize> Debug for Sodg<N> {
             let mut attrs = vtx
                 .edges
                 .iter()
-                .map(|edge| format!("\n\t{} ➞ ν{}", edge.label, edge.to))
+                .map(|edge| {
+                    let label = self.edge_label_text(edge);
+                    format!("\n\t{label} ➞ ν{}", edge.to)
+                })
                 .collect::<Vec<String>>();
             if vtx.persistence != Persistence::Empty {
                 attrs.push(format!("{}", vtx.data));
@@ -62,7 +65,7 @@ impl<const N: usize> Sodg<N> {
         let list: Vec<String> = vtx
             .edges
             .iter()
-            .map(|edge| format!("{}", edge.label))
+            .map(|edge| self.edge_label_text(edge).into_owned())
             .collect();
         Ok(format!(
             "ν{v}⟦{}{}⟧",


### PR DESCRIPTION
## Summary
- route all diagnostic formatting through the label interner by exposing `edge_label_text` and updating debug/DOT/XML/inspect output helpers to operate on interned strings.
- generalize slicing to work with canonical label text, rebuilding labels via `Label::from_str` and extending docs/tests to match the new predicate signature.
- keep the edge list and index consistent during merges by reusing the shared edge update helper and avoiding manual vertex cloning.

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo audit`
- `cargo deny check` *(fails: failed to fetch advisory database)*
