### PR TITLE
#232: Rebuild vertex indexes during graph deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ struct Vertex<const N: usize> {
     data: Hex,
     persistence: Persistence,
     edges: Vec<Edge>,
+    #[serde(skip)]
     index: EdgeIndex,
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -30,6 +30,14 @@ impl<const N: usize> Vertex<N> {
         self.index.insert(label_id, destination);
     }
 
+    pub(crate) fn rebuild_index(&mut self) {
+        let pairs = self
+            .edges
+            .iter()
+            .map(|edge| (edge.label_id, Sodg::<N>::encode_vertex_id(edge.to)));
+        self.index.rebuild(pairs);
+    }
+
     #[allow(dead_code)]
     fn remove_edge(&mut self, label_id: LabelId) -> Option<Edge> {
         let position = self


### PR DESCRIPTION
## Summary
- mark vertex edge indexes as derived data and rebuild them from serialized edges after loading a graph
- ensure Sodg::load repopulates each vertex index so kid lookups keep working across save/load cycles
- extend the serialization test to cover edge lookups and label interner persistence after deserialization

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo test --all
- cargo clippy -- -D warnings
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: unable to fetch advisory database due to network error)*

