### PR TITLE
#232: Use shared backing storage for Hex payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,18 +903,38 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.227"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,6 +1004,7 @@ dependencies = [
  "rstest",
  "rustc-hash",
  "serde",
+ "serde_bytes",
  "simple_logger",
  "sxd-document",
  "sxd-xpath",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1.11.1"
 rstest = "0.26.0"
 rustc-hash = "2.1.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_bytes = "0.11.15"
 simple_logger = "5.0.0"
 sxd-document = "0.3.2"
 sxd-xpath = "0.4.2"

--- a/src/edge_index.rs
+++ b/src/edge_index.rs
@@ -152,13 +152,14 @@ mod tests {
     #[test]
     fn promotes_once_threshold_exceeded() {
         let mut index = EdgeIndex::new();
-        for label in 0..SMALL_THRESHOLD as u32 {
+        let threshold = u32::try_from(SMALL_THRESHOLD).expect("SMALL_THRESHOLD fits into u32");
+        for label in 0..threshold {
             index.insert(label, label + 1);
         }
         assert!(matches!(index, EdgeIndex::Small(_)));
-        index.insert(SMALL_THRESHOLD as u32, 99);
+        index.insert(threshold, 99);
         assert!(matches!(index, EdgeIndex::Large(_)));
-        assert_eq!(Some(99), index.get(SMALL_THRESHOLD as u32));
+        assert_eq!(Some(99), index.get(threshold));
     }
 
     #[test]
@@ -167,7 +168,8 @@ mod tests {
         index.insert(1, 2);
         assert_eq!(Some(2), index.remove(1));
         assert_eq!(None, index.remove(1));
-        index.rebuild((0..=SMALL_THRESHOLD as u32).map(|label| (label, label + 1)));
+        let threshold = u32::try_from(SMALL_THRESHOLD).expect("SMALL_THRESHOLD fits into u32");
+        index.rebuild((0..=threshold).map(|label| (label, label + 1)));
         assert!(matches!(index, EdgeIndex::Large(_)));
         assert_eq!(Some(2), index.remove(1));
         assert_eq!(None, index.get(1));

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -153,8 +153,10 @@ mod tests {
 
     #[test]
     fn respects_capacity_limit() {
-        let mut interner = LabelInterner::default();
-        interner.next = NextLabelId(LabelId::MAX);
+        let mut interner = LabelInterner {
+            next: NextLabelId(LabelId::MAX),
+            ..LabelInterner::default()
+        };
         let label = Label::Alpha(123);
         assert!(matches!(
             interner.get_or_intern(&label),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![allow(clippy::multiple_crate_versions)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -73,9 +74,9 @@ const MAX_BRANCH_SIZE: usize = 16;
 /// let d = Hex::from(65534_i64);
 /// assert_eq!(65534, d.to_i64().unwrap());
 /// ```
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Clone)]
 pub enum Hex {
-    Vector(Vec<u8>),
+    Shared(Arc<[u8]>),
     Bytes([u8; HEX_SIZE], usize),
 }
 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -103,13 +103,13 @@ mod tests {
         g.put(0, &Hex::from_str_bytes("hello"));
         g.add(1);
         let label = Label::from_str("foo").unwrap();
-        g.bind(0, 1, label.clone());
+        g.bind(0, 1, label);
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("foo.sodg");
         g.save(file.as_path()).unwrap();
         let after: Sodg<1> = Sodg::load(file.as_path()).unwrap();
         assert_eq!(g.inspect(0).unwrap(), after.inspect(0).unwrap());
-        assert_eq!(Some(1), after.kid(0, label.clone()));
+        assert_eq!(Some(1), after.kid(0, label));
         let (loaded_label, destination) = after.kids(0).next().unwrap();
         assert_eq!(&label, loaded_label);
         assert_eq!(1, *destination);


### PR DESCRIPTION
## Summary
- replace `Hex::Vector` with a shared `Arc<[u8]>` representation and adjust indexing, conversion, and concatenation logic accordingly
- implement manual serde support for `Hex`, add a shared-storage-friendly clone path in graph storage, and update tests to assert inline/shared behavior
- add serde-bytes dependency and strengthen helper tests in edge index and label interner modules

## Testing
- cargo +nightly fmt --
- cargo clippy --all-targets -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
