### PR TITLE
#232: Improve garbage collection cleanup paths

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -172,7 +172,9 @@ mod tests {
         );
         let total = s.deploy_to(&mut g).unwrap();
         assert_eq!(4, total);
+        let label = Label::from_str("foo").unwrap();
+        assert_eq!(1, g.kid(0, label.clone()).unwrap());
         assert_eq!("привет", g.data(1).unwrap().to_utf8().unwrap());
-        assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
+        assert!(g.kid(0, label).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- add internal helpers to gather branch members, prune inbound edges, and reset vertices during garbage collection
- update `Sodg::data` to defer branch cleanup until immutable borrows are released and rely on the new helpers for edge/index updates
- extend garbage-collection coverage in `ops` tests and adjust the script test to reflect edge removal after data retrieval

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo deny check` *(fails: unable to fetch advisory database due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68d625710d60832b89e55bc0049101b5