### PR TITLE
#232: Update tests for KidRef iterator behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ transitively point to it.
 Here is how you can create a di-graph:
 
 ```rust
-use sodg::Sodg;
-use sodg::Hex;
+use std::str::FromStr as _;
+use sodg::{Hex, Label, Sodg};
 let mut g = Sodg::empty(256);
 g.add(0); // add a vertex no.0
 g.add(1); // add a vertex no.1
-g.bind(0, 1, "foo"); // connect v0 to v1 with label "foo"
+g.bind(0, 1, Label::from_str("foo").unwrap()); // connect v0 to v1 with label "foo"
+g.bind(0, 1, Label::from_str("bar").unwrap()); // add another edge with label "bar"
 g.put(1, &Hex::from_str_bytes("Hello, world!")); // attach data to v1
 ```
 
@@ -35,17 +36,19 @@ Then, you can find a vertex by the label of an edge departing
 from another vertex:
 
 ```rust
-let id = g.kid(0, "foo");
+let id = g.kid(0, Label::from_str("foo").unwrap()).unwrap();
 assert_eq!(1, id);
 ```
 
 Then, you can find all kids of a vertex:
 
 ```rust
-let kids: Vec<(String, String, usize)> = g.kids(0);
-assert_eq!("foo", kids[0].0);
-assert_eq!("bar", kids[0].1);
-assert_eq!(1, kids[0].2);
+let mut kids = g.kids(0);
+let first = kids.next().unwrap();
+assert_eq!("foo", first.label().to_string());
+assert_eq!(1, first.destination());
+let second = kids.next().unwrap();
+assert_eq!("bar", second.label().to_string());
 ```
 
 Then, you can read the data of a vertex:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod slice;
 mod xml;
 
 pub use crate::labels::{LabelId, LabelInterner, LabelInternerError};
+pub use crate::ops::KidRef;
 pub use edge_index::{Edge, EdgeIndex, SMALL_THRESHOLD};
 
 const HEX_SIZE: usize = 8;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -82,23 +82,27 @@ impl<const N: usize> Sodg<N> {
         if g.vertices.get(right).unwrap().persistence != Persistence::Empty {
             self.put(left, &g.vertices.get(right).unwrap().data);
         }
-        for (a, to) in g.kids(right) {
-            let matched = if let Some(t) = self.kid(left, *a) {
+        for kid in g.kids(right) {
+            let label = *kid.label();
+            let destination = kid.destination();
+            let matched = if let Some(t) = self.kid(left, label) {
                 t
-            } else if let Some(t) = mapped.get(to) {
-                self.bind(left, *t, *a);
+            } else if let Some(t) = mapped.get(&destination) {
+                self.bind(left, *t, label);
                 *t
             } else {
                 let id = self.next_id();
                 self.add(id);
-                self.bind(left, id, *a);
+                self.bind(left, id, label);
                 id
             };
-            self.merge_rec(g, matched, *to, mapped)?;
+            self.merge_rec(g, matched, destination, mapped)?;
         }
-        for (a, to) in g.kids(right) {
-            if let Some(first) = self.kid(left, *a)
-                && let Some(second) = mapped.get(to)
+        for kid in g.kids(right) {
+            let label = *kid.label();
+            let destination = kid.destination();
+            if let Some(first) = self.kid(left, label)
+                && let Some(second) = mapped.get(&destination)
                 && first != *second
             {
                 self.join(first, *second);


### PR DESCRIPTION
## Summary
- expose the new `KidRef` iterator item and update graph consumers/tests to use it
- expand kid-related coverage, including index promotion/removal scenarios and multi-segment `find` checks
- add serialization and label interner round-trip tests and refresh README usage examples

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo test --all
- cargo clippy -- -D warnings
- cargo doc --no-deps
- cargo audit
- cargo deny check (fails: unable to fetch advisory DB due to missing git repository)
