### PR TITLE
#232: Document label interning and edge indexing internals

### DIFF
--- a/docs/edge_index.md
+++ b/docs/edge_index.md
@@ -1,0 +1,41 @@
+# Edge index design note
+
+## Overview
+
+Outbound edges on a vertex are exposed through `Sodg::kids`, which must remain
+fast for both sparse and dense vertices. The `EdgeIndex` helps by providing an
+adaptive mapping from interned label identifiers to destination vertex ids.
+
+## Rationale
+
+* **Small graph bias:** Most vertices in EO programs have a handful of outbound
+  edges. A fixed-capacity `micromap::Map` keeps those lookups allocation-free and
+  iteration-friendly.
+* **Seamless growth:** Vertices that grow beyond 32 distinct labels transparently
+  promote the index to a standard `HashMap`. This keeps lookup complexity at
+  `O(1)` without imposing hash-table costs on the common, tiny case.
+* **Label interning:** Storing `LabelId` instead of `Label` drastically reduces
+  the size of the keys inside the index, improving cache locality for traversal
+  heavy workloads.
+
+## Trade-offs
+
+* **Promotion cost:** The first insertion beyond the small-map threshold walks
+  the entire map to populate the `HashMap`. Benchmarks show this one-time cost is
+  more than offset by faster lookups in the dense regime.
+* **Two sources of truth:** The vertex keeps the `Vec<Edge>` as the canonical
+  record while the index mirrors it. Tests assert that rebuilds and removals keep
+  the two data structures synchronized.
+* **Identifier limits:** `LabelId` and encoded vertex identifiers are `u32` to
+  keep the index compact. Consumers must ensure the graph size stays within the
+  representable range.
+
+## Maintenance tips
+
+* When changing the promotion threshold, update both `SMALL_THRESHOLD` and the
+  benchmark scenarios in `benches/bench.rs` to keep performance coverage honest.
+* Any new mutation on `Vertex` must update the index alongside the edge list;
+  add regression tests whenever you introduce a new code path.
+* The label interner guarantees that equal labels share an identifier. If the
+  interner changes, revisit the debug assertions in the iterator implementation
+  to keep the mirror intact.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,22 @@
 //! it's time to delete some vertices (something similar to
 //! "garbage collection").
 //!
+//! Behind the API the crate combines three performance-oriented
+//! building blocks:
+//!
+//! * Labels are interned via [`LabelInterner`], which canonicalizes each
+//!   [`Label`] into its UTF-8 representation so that high-level code keeps the
+//!   typed enum while the engine manipulates compact numeric identifiers.
+//! * Outbound edges are tracked by [`EdgeIndex`], a hybrid structure that
+//!   starts with a small, fixed-capacity map and seamlessly upgrades to a
+//!   hash map once the vertex degree grows past [`edge_index::SMALL_THRESHOLD`].
+//!   This avoids the cost of hashing in the common case but keeps large graphs
+//!   responsive.
+//! * [`Hex`] payloads use a dual representation: stack-allocated arrays serve
+//!   short blobs, while larger data is shared through reference-counted slices.
+//!   Graph traversals therefore copy as little as possible while still offering
+//!   cheap cloning semantics for read-heavy workloads.
+//!
 //! For example, here is how you create a simple
 //! di-graph with two vertices and an edge between them:
 //!


### PR DESCRIPTION
## Summary
- expand the crate-level docs and README to call out label interning, the hybrid edge index, and the dual Hex storage strategy
- add rustdoc examples and invariants for `LabelInterner`, `EdgeIndex`, `Edge`, and the `Sodg::kids` iterator helpers
- write a short design note that captures the motivations, trade-offs, and maintenance guidance for the adaptive edge index

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
