### PR TITLE
#232: Use SmallVec for branch storage to lift capacity limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,15 +606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "microstack"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84c0e18714cc3401b78d510d2a8874c5c3b1706eb08a647c718e9f686b5d59e"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sodg"
 version = "0.0.0"
 dependencies = [
@@ -1084,7 +1084,6 @@ dependencies = [
  "libc",
  "log",
  "micromap",
- "microstack",
  "nohash-hasher",
  "openssl",
  "predicates",
@@ -1094,6 +1093,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "simple_logger",
+ "smallvec",
  "sxd-document",
  "sxd-xpath",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lazy_static = "1.5.0"
 libc = "0.2.174"
 log = "0.4.27"
 micromap = { version = "0.1.0", features = ["serde"] }
-microstack = { version = "0.0.7", features = ["serde"] }
+smallvec = { version = "1.15.1", features = ["serde"] }
 nohash-hasher = "0.2.0"
 openssl = { version = "0.10.73", features = ["vendored"] }
 regex = "1.11.1"

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -3,7 +3,9 @@
 
 use emap::Map;
 
-use crate::{EdgeIndex, Hex, LabelInterner, MAX_BRANCHES, Persistence, Sodg, Vertex};
+use crate::{
+    BranchMembers, EdgeIndex, Hex, LabelInterner, MAX_BRANCHES, Persistence, Sodg, Vertex,
+};
 
 impl<const N: usize> Sodg<N> {
     /// Make an empty [`Sodg`], with no vertices and no edges.
@@ -25,12 +27,12 @@ impl<const N: usize> Sodg<N> {
                 },
             ),
             stores: Map::with_capacity_some(MAX_BRANCHES, 0),
-            branches: Map::with_capacity_some(MAX_BRANCHES, microstack::Stack::new()),
+            branches: Map::with_capacity_some(MAX_BRANCHES, BranchMembers::new()),
             labels: LabelInterner::default(),
             next_v: 0,
         };
-        g.branches.insert(0, microstack::Stack::from_vec(vec![0]));
-        g.branches.insert(1, microstack::Stack::from_vec(vec![0]));
+        g.branches.insert(0, BranchMembers::from_vec(vec![0]));
+        g.branches.insert(1, BranchMembers::from_vec(vec![0]));
         g
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 mod clone;
 mod ctors;
@@ -71,7 +72,9 @@ pub use edge_index::{Edge, EdgeIndex, SMALL_THRESHOLD};
 
 const HEX_SIZE: usize = 8;
 const MAX_BRANCHES: usize = 16;
-const MAX_BRANCH_SIZE: usize = 16;
+const BRANCH_INLINE_CAPACITY: usize = 16;
+
+type BranchMembers = SmallVec<[usize; BRANCH_INLINE_CAPACITY]>;
 
 /// An object-oriented representation of binary data
 /// in hexadecimal format, which can be put into vertices of the graph.
@@ -152,7 +155,7 @@ pub struct Script {
 #[derive(Serialize, Deserialize)]
 pub struct Sodg<const N: usize> {
     stores: emap::Map<usize>,
-    branches: emap::Map<microstack::Stack<usize, MAX_BRANCH_SIZE>>,
+    branches: emap::Map<BranchMembers>,
     vertices: emap::Map<Vertex<N>>,
     /// Interned labels that back the graph's edge metadata.
     labels: LabelInterner,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -759,6 +759,20 @@ mod tests {
     }
 
     #[test]
+    fn grows_branch_beyond_inline_capacity() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        for vertex in 1..=20 {
+            g.add(vertex);
+            g.bind(0, vertex, Label::Alpha(vertex));
+        }
+        let branch = g.vertices.get(0).unwrap().branch;
+        let members = g.branches.get(branch).unwrap();
+        assert!(members.len() > 16);
+        assert!(members.contains(&20));
+    }
+
+    #[test]
     fn kid_handles_single_edge_vertex() {
         let g = build_vertex_with_degree(1);
         let vertex = g.vertices.get(0).unwrap();


### PR DESCRIPTION
## Summary
- replace the microstack-backed branch storage with `SmallVec` so dynamic binding is no longer capped at 16 entries
- update the graph constructors to create and seed the new branch containers
- add a regression test that binds more than sixteen vertices into a single branch without panicking

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
