### PR TITLE
#232: Optimize label canonicalization for interner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1078,7 @@ name = "sodg"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "bincode 2.0.1",
  "criterion",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ libc = "0.2.174"
 log = "0.4.27"
 micromap = { version = "0.1.0", features = ["serde"] }
 smallvec = { version = "1.15.1", features = ["serde"] }
+arrayvec = "0.7.6"
 nohash-hasher = "0.2.0"
 openssl = { version = "0.10.73", features = ["vendored"] }
 regex = "1.11.1"


### PR DESCRIPTION
## Summary
- introduce an inline `CanonicalLabel` representation backed by `ArrayString` to avoid heap allocations for common labels
- update `LabelInterner` to canonicalize via borrowed `&str` lookups while storing owned strings only once
- extend label tests with canonicalization assertions and allocation instrumentation to guard no-allocation paths

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
