### PR TITLE
#232: Use FxHasher for label interner hash maps

### DIFF
--- a/src/labels.rs
+++ b/src/labels.rs
@@ -12,8 +12,10 @@
 
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter, Result as FmtResult, Write as _};
+use std::hash::BuildHasherDefault;
 
 use arrayvec::ArrayString;
+use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 
 use crate::Label;
@@ -68,8 +70,8 @@ impl std::error::Error for LabelInternerError {}
 /// ```
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LabelInterner {
-    forward: HashMap<String, LabelId>,
-    reverse: HashMap<LabelId, String>,
+    forward: HashMap<String, LabelId, BuildHasherDefault<FxHasher>>,
+    reverse: HashMap<LabelId, String, BuildHasherDefault<FxHasher>>,
     #[serde(default)]
     next: NextLabelId,
 }


### PR DESCRIPTION
## Summary
- update the label interner to build its forward and reverse maps with `BuildHasherDefault<FxHasher>` to reduce hashing overhead

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo test --all
- cargo clippy -- -D warnings
- cargo doc --no-deps
- cargo bench
- cargo audit
- cargo deny check
