### PR TITLE
#232: Optimize alpha label canonicalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "hex",
  "iai-callgrind",
  "itertools 0.14.0",
+ "itoa",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bincode = { version = "2.0.1", features = ["serde"] }
 ctor = "0.4.2"
 emap = { version = "0.0.13", features = ["serde"] }
 hex = "0.4.3"
+itoa = "1.0.11"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 libc = "0.2.174"

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -288,12 +288,7 @@ impl LabelKeyRef<'_> {
         #[cfg(test)]
         boxed_string_allocations::increment();
         match self.repr {
-            LabelKeyRepr::Alpha(index) => {
-                let mut text = String::new();
-                text.push('α');
-                text.push_str(&index.to_string());
-                text.into_boxed_str()
-            }
+            LabelKeyRepr::Alpha(index) => alpha_label_text(index).into_boxed_str(),
             LabelKeyRepr::Greek(symbol) => symbol.to_string().into_boxed_str(),
             LabelKeyRepr::Str(trimmed) => trimmed.into_string().into_boxed_str(),
         }
@@ -301,12 +296,7 @@ impl LabelKeyRef<'_> {
 
     fn canonical_string(&self) -> String {
         match self.repr {
-            LabelKeyRepr::Alpha(index) => {
-                let mut text = String::new();
-                text.push('α');
-                text.push_str(&index.to_string());
-                text
-            }
+            LabelKeyRepr::Alpha(index) => alpha_label_text(index),
             LabelKeyRepr::Greek(symbol) => symbol.to_string(),
             LabelKeyRepr::Str(trimmed) => trimmed.into_string(),
         }
@@ -326,6 +316,15 @@ impl LabelKeyRef<'static> {
             Label::Str(chars) => LabelKeyRepr::Str(TrimmedStr::from_chars(chars)?),
         }))
     }
+}
+
+fn alpha_label_text(index: usize) -> String {
+    let mut buffer = itoa::Buffer::new();
+    let digits = buffer.format(index);
+    let mut text = String::with_capacity(1 + digits.len());
+    text.push('α');
+    text.push_str(digits);
+    text
 }
 
 /// Owned canonical label key used as a hash-map entry.


### PR DESCRIPTION
## Summary
- format alpha labels with an `itoa::Buffer` to avoid intermediate heap allocations when canonicalizing labels
- reuse the helper when materializing borrowed alpha labels to ensure consistent minimal allocation paths

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(fails: could not fetch advisory database)*
