### PR TITLE
#232: Add preinterned label binding fast path

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -56,13 +56,18 @@ fn bench_bind_edges(c: &mut Criterion) {
     for &size in &sizes {
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
             let mut graph = setup_graph(size);
+            let label = Label::Alpha(0);
+            let label_id = graph
+                .intern_label(&label)
+                .expect("failed to intern benchmark label");
             b.iter(|| {
                 for i in 0..size - 1 {
                     if i % 16 != 0 {
-                        black_box(graph.bind(
+                        black_box(graph.bind_with_label_id(
                             black_box(i),
                             black_box(i + 1),
-                            black_box(Label::Alpha(0)),
+                            black_box(label_id),
+                            black_box(label),
                         ));
                     }
                 }

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -165,6 +165,29 @@ impl LabelInterner {
         self.forward.get(&key).copied()
     }
 
+    /// Retrieve the identifier previously assigned to [`label`](Label) without
+    /// mutating the interner.
+    ///
+    /// The method is intentionally equivalent to [`get`](Self::get) but keeps
+    /// semantic clarity when callers specifically need to access a cached
+    /// identifier. It returns [`None`] if the label was not interned yet.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sodg::{Label, LabelInterner};
+    ///
+    /// let mut interner = LabelInterner::default();
+    /// let label = Label::Alpha(1);
+    /// let id = interner.get_or_intern(&label).unwrap();
+    /// assert_eq!(Some(id), interner.lookup(&label));
+    /// assert!(interner.lookup(&Label::Alpha(99)).is_none());
+    /// ```
+    #[must_use]
+    pub fn lookup(&self, label: &Label) -> Option<LabelId> {
+        self.get(label)
+    }
+
     /// Resolve an identifier into its canonical UTF-8 label.
     ///
     /// # Examples
@@ -399,6 +422,15 @@ mod tests {
         let label = Label::Str(['f', 'o', 'o', ' ', ' ', 'b', 'a', 'r']);
         let key = LabelKey::from_label(&label).unwrap();
         assert_eq!("foobar", key.as_str());
+    }
+
+    #[test]
+    fn lookup_returns_identifier_without_mutation() {
+        let mut interner = LabelInterner::default();
+        let label = Label::Alpha(3);
+        assert!(interner.lookup(&label).is_none());
+        let id = interner.get_or_intern(&label).unwrap();
+        assert_eq!(Some(id), interner.lookup(&label));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose cached label identifiers through `LabelInterner::lookup` and new `Sodg` helpers
- add `Sodg::bind_with_label_id` to reuse preinterned labels while preserving existing `bind`
- extend benches and tests to cover the new entry point and cached identifiers

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check *(aborted because dependency build exceeded reasonable time)*
