### PR TITLE
#232: Validate canonical labels for pre-interned bindings

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -63,12 +63,16 @@ fn bench_bind_edges(c: &mut Criterion) {
             b.iter(|| {
                 for i in 0..size - 1 {
                     if i % 16 != 0 {
-                        black_box(graph.bind_with_label_id(
-                            black_box(i),
-                            black_box(i + 1),
-                            black_box(label_id),
-                            black_box(label),
-                        ));
+                        black_box(
+                            graph
+                                .bind_with_label_id(
+                                    black_box(i),
+                                    black_box(i + 1),
+                                    black_box(label_id),
+                                    black_box(label),
+                                )
+                                .expect("benchmark label must remain interned"),
+                        );
                     }
                 }
                 black_box(&mut graph);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ mod slice;
 mod xml;
 
 pub use crate::labels::{LabelId, LabelInterner, LabelInternerError};
-pub use crate::ops::KidRef;
+pub use crate::ops::{BindError, KidRef};
 pub use edge_index::{Edge, EdgeIndex, SMALL_THRESHOLD};
 
 const HEX_SIZE: usize = 8;


### PR DESCRIPTION
## Summary
- retain canonical `Label` instances alongside interned strings in `LabelInterner` and expose a lookup helper
- validate pre-interned bindings through the new `BindError`, rejecting unknown or mismatched labels while keeping vertices populated with canonical labels
- update serialization, benches, and tests to cover the stricter label validation path

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
