### PR TITLE
#232: Track edge slots in EdgeIndex

### DIFF
--- a/benches/bench_utils.rs
+++ b/benches/bench_utils.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Write as _;
 
-use sodg::{EdgeIndex, Label, LabelId, Sodg};
+use sodg::{EdgeIndex, EdgeIndexEntry, Label, LabelId, Sodg};
 
 /// Benchmark degrees that exercise both variants of [`EdgeIndex`].
 pub(crate) const BENCHMARK_DEGREES: [usize; 5] = [1, 31, 32, 33, 64];
@@ -22,7 +22,13 @@ pub(crate) fn label_ids_for_degree(degree: usize) -> Vec<LabelId> {
 pub(crate) fn populate_edge_index(index: &mut EdgeIndex, labels: &[LabelId]) {
     for (offset, label) in labels.iter().enumerate() {
         let destination = (offset + 1) as u32;
-        index.insert(*label, destination);
+        index.insert(
+            *label,
+            EdgeIndexEntry {
+                destination,
+                slot: offset,
+            },
+        );
     }
 }
 
@@ -89,7 +95,9 @@ pub(crate) fn dense_graph_with_locator<const N: usize>(
         let _ = write!(locator, "{}", main_label);
         for filler in 1..degree {
             let filler_label = Label::Alpha(segment + filler * depth);
-            graph.bind(current, next_vertex + filler, filler_label).unwrap();
+            graph
+                .bind(current, next_vertex + filler, filler_label)
+                .unwrap();
         }
         current = next_vertex;
         next_vertex += degree.max(1);

--- a/docs/edge_index.md
+++ b/docs/edge_index.md
@@ -28,8 +28,10 @@ adaptive mapping from interned label identifiers to destination vertex ids.
   smoothen allocations across the 30–40 degree window. Callers should expect the
   amortized cost of inserts to stay nearly flat after the first promotion.
 * **Two sources of truth:** The vertex keeps the `Vec<Edge>` as the canonical
-  record while the index mirrors it. Tests assert that rebuilds and removals keep
-  the two data structures synchronized.
+  record while the index mirrors it. Each index entry stores the encoded
+  destination together with the slot of the corresponding `Edge`, allowing
+  updates to mutate edges directly without scanning the adjacency list. Tests
+  assert that rebuilds and removals keep the two data structures synchronized.
 * **Identifier limits:** `LabelId` and encoded vertex identifiers are `u32` to
   keep the index compact. Consumers must ensure the graph size stays within the
   representable range.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod xml;
 
 pub use crate::labels::{LabelId, LabelInterner, LabelInternerError};
 pub use crate::ops::{BindError, KidRef};
-pub use edge_index::{Edge, EdgeIndex, SMALL_THRESHOLD};
+pub use edge_index::{Edge, EdgeIndex, EdgeIndexEntry, SMALL_THRESHOLD};
 
 const HEX_SIZE: usize = 8;
 const MAX_BRANCHES: usize = 16;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -135,7 +135,13 @@ mod tests {
         assert_eq!(vertex.edges.len(), vertex.index.len());
         for edge in &vertex.edges {
             let encoded = u32::try_from(edge.to).expect("vertex identifier fits into u32");
-            assert_eq!(Some(encoded), vertex.index.get(edge.label_id));
+            assert_eq!(
+                Some(encoded),
+                vertex
+                    .index
+                    .get(edge.label_id)
+                    .map(|entry| entry.destination),
+            );
             let label_text = after.edge_label_text(edge);
             let parsed = Label::from_str(label_text.as_ref()).expect("edge label parsed");
             assert_eq!(edge.to, after.kid(0, parsed).expect("kid found after load"));


### PR DESCRIPTION
## Summary
- store destination and slot metadata in `EdgeIndex` to support constant-time updates
- update vertex mutation paths to reuse stored slots and keep the index synchronized during inserts and removals
- extend documentation, benches, and tests to cover the slot-aware behavior and constant comparison counts

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
